### PR TITLE
Single quotes and empty attributes

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -108,8 +108,12 @@ class Parser {
           pugNode += `.${value.split(' ').join('.')}`
           break
         default:
-          const q = /'/.test(value) ? '"' : "'"
-          attributeList.push(`${name}=${q}${value}${q}`)
+          if (!value) {
+            attributeList.push(`${name}`)
+          } else {
+            const q = /'/.test(value) ? '"' : "'"
+            attributeList.push(`${name}=${q}${value}${q}`)
+          }
           break
       }
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -108,7 +108,8 @@ class Parser {
           pugNode += `.${value.split(' ').join('.')}`
           break
         default:
-          attributeList.push(`${name}='${value}'`)
+          const q = /'/.test(value) ? '"' : "'"
+          attributeList.push(`${name}=${q}${value}${q}`)
           break
       }
 

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ const html = `<!doctype html>
   <body>
     <div id="content">
       <h1 class="accents">â, é, ï, õ, ù</h1>
+      <h2 aria-label="Tests with single quotes don't fail">Text</h2>
     </header>
   </body>
 </html>`
@@ -19,7 +20,8 @@ html(lang='en')
     title Hello World!
   body
     #content
-      h1.accents â, é, ï, õ, ù`
+      h1.accents â, é, ï, õ, ù
+      h2(aria-label="Tests with single quotes don't fail") Text`
 
 test('Pug', t => {
   const generated = html2pug(html)

--- a/test.js
+++ b/test.js
@@ -9,7 +9,6 @@ const html = `<!doctype html>
   <body>
     <div id="content">
       <h1 class="accents">â, é, ï, õ, ù</h1>
-      <h2 aria-label="Tests with single quotes don't fail">Text</h2>
     </header>
   </body>
 </html>`
@@ -20,8 +19,7 @@ html(lang='en')
     title Hello World!
   body
     #content
-      h1.accents â, é, ï, õ, ù
-      h2(aria-label="Tests with single quotes don't fail") Text`
+      h1.accents â, é, ï, õ, ù`
 
 test('Pug', t => {
   const generated = html2pug(html)
@@ -40,5 +38,26 @@ test('Tabs', t => {
   })
 
   const expected = 'div\n\tspan Tabs!'
+  t.is(generated, expected)
+})
+
+test('Single quotes in attributes', t => {
+  const generated = html2pug(
+    `<i aria-label="Tests with single quotes don't fail"></i>`,
+    {
+      fragment: true
+    }
+  )
+
+  const expected = `i(aria-label="Tests with single quotes don't fail")`
+  t.is(generated, expected)
+})
+
+test('Empty attributes', t => {
+  const generated = html2pug(`<span translate #templatevar>Test</span>`, {
+    fragment: true
+  })
+
+  const expected = `span(translate, #templatevar) Test`
   t.is(generated, expected)
 })


### PR DESCRIPTION
Hi,
I was converting some Angular templates to pug and noticed that if there are single quotes in attribute values the result is invalid, e.g. `<h2 class="'x'"></h2> --> h2(class=''x'')`. I changed this so the parser outputs double quotes for these attributes, resulting in `h2(class="'x'")`.

I also thought I'd leave out attribute values that are empty: `span(translate)` instead of `span(translate='')`.