### PR TITLE
Fix typo in the html block of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Turns this :unamused:
   <body>
     <div id="content">
       <h1 class="title">Hello World!</h1>
-    </header>
+    </div>
   </body>
 </html>
 ```


### PR DESCRIPTION
The closing block for the `div#content` tag was `header` instead of
`div`. Not sure if this was intentional but I've fixed it